### PR TITLE
Add distinction for unvisited comments

### DIFF
--- a/review-notifications/src/Github.css
+++ b/review-notifications/src/Github.css
@@ -31,8 +31,23 @@ a.buttonHover:hover {
   margin-top: 0px;
 }
 
+.isNew p {
+  font-weight: 900;
+  color: rgba(0.8, 0.8, 0.8, 0.8);
+}
+
 /*button more or less*/
-.moreOrLess {
+.commentButton.left {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 20px;
+  width: 90px;
+  font-size: 10px;
+  color: gray !important;
+}
+
+.commentButton.right {
   position: absolute;
   right: 0;
   bottom: 0;
@@ -42,7 +57,7 @@ a.buttonHover:hover {
   color: gray !important;
 }
 
-.moreOrLess {
+.commentButton {
   border: none;
   border-radius: 4px;
   background-color: transparent;
@@ -50,7 +65,7 @@ a.buttonHover:hover {
   text-align: center;
 }
 
-.moreOrLess:hover {
+.commentButton:hover {
   background-color: #a7a5a5;
   color: white;
 }

--- a/review-notifications/src/Github.js
+++ b/review-notifications/src/Github.js
@@ -241,6 +241,12 @@ class Github extends Component {
                         component="a"
                         className="buttonHover padding"
                         href={pr.link}
+                        onClick={() => {
+                          if (pr.hasNewComment) {
+                            pr.hasNewComment = false;
+                            this.saveInStorage();
+                          }
+                        }}
                         style={{ textDecoration: 'none' }}
                         target="_blank"
                         rel="noopener noreferrer"
@@ -257,9 +263,9 @@ class Github extends Component {
                     }
                     secondary={
                       <div
-                        className={
-                          'paddingComment ' + (pr.hasNewComment ? 'isNew' : '')
-                        }
+                        className={`paddingComment ${
+                          pr.hasNewComment ? 'isNew' : ''
+                        }`}
                       >
                         <div name="showMoreOrLess">{this.listComments(pr)}</div>
                         <button
@@ -270,7 +276,7 @@ class Github extends Component {
                           show more
                         </button>
                         <button
-                          ref={this.handleReadOnLoad}
+                          ref={this.handleReadButtonOnLoad}
                           data-length={pr.commentsData.length}
                           data-isnew={pr.hasNewComment}
                           className="commentButton left"
@@ -382,6 +388,12 @@ class Github extends Component {
                       component="a"
                       className="buttonHover padding"
                       href={pr.link}
+                      onClick={() => {
+                        if (pr.hasNewComment) {
+                          pr.hasNewComment = false;
+                          this.saveInStorage();
+                        }
+                      }}
                       style={{ textDecoration: 'none' }}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -398,9 +410,9 @@ class Github extends Component {
                   }
                   secondary={
                     <div
-                      className={
-                        'paddingComment ' + (pr.hasNewComment ? 'isNew' : '')
-                      }
+                      className={`paddingComment ${
+                        pr.hasNewComment ? 'isNew' : ''
+                      }`}
                     >
                       <div name="showMoreOrLess">{this.listComments(pr)}</div>
                       <button
@@ -411,7 +423,7 @@ class Github extends Component {
                         Show more
                       </button>
                       <button
-                        ref={this.handleReadOnLoad}
+                        ref={this.handleReadButtonOnLoad}
                         data-length={pr.commentsData.length}
                         data-isnew={pr.hasNewComment}
                         className="commentButton left"
@@ -483,9 +495,9 @@ class Github extends Component {
     this.saveInStorage();
   }
 
-  handleReadOnLoad(e) {
+  handleReadButtonOnLoad(e) {
     if (e) {
-      if (e.dataset.length == 0) {
+      if (e.dataset.length === 0) {
         e.classList.add('hidden');
       }
       if (e.dataset.isNew) {

--- a/review-notifications/src/Github.js
+++ b/review-notifications/src/Github.js
@@ -256,14 +256,27 @@ class Github extends Component {
                       </Grid>
                     }
                     secondary={
-                      <div className="paddingComment">
+                      <div
+                        className={
+                          'paddingComment ' + (pr.hasNewComment ? 'isNew' : '')
+                        }
+                      >
                         <div name="showMoreOrLess">{this.listComments(pr)}</div>
                         <button
                           ref={this.handleDisplayButton}
-                          className="moreOrLess"
+                          className="commentButton right"
                           onClick={this.handleMoreLess}
                         >
                           show more
+                        </button>
+                        <button
+                          ref={this.handleReadOnLoad}
+                          data-length={pr.commentsData.length}
+                          data-isnew={pr.hasNewComment}
+                          className="commentButton left"
+                          onClick={this.handleReadButton.bind(this, pr)}
+                        >
+                          {pr.hasNewComment ? 'Mark as read' : 'Mark as unread'}
                         </button>
                       </div>
                     }
@@ -384,14 +397,27 @@ class Github extends Component {
                     </Grid>
                   }
                   secondary={
-                    <div className="paddingComment">
+                    <div
+                      className={
+                        'paddingComment ' + (pr.hasNewComment ? 'isNew' : '')
+                      }
+                    >
                       <div name="showMoreOrLess">{this.listComments(pr)}</div>
                       <button
                         ref={this.handleDisplayButton}
-                        className="moreOrLess"
+                        className="commentButton right"
                         onClick={this.handleMoreLess}
                       >
                         Show more
+                      </button>
+                      <button
+                        ref={this.handleReadOnLoad}
+                        data-length={pr.commentsData.length}
+                        data-isnew={pr.hasNewComment}
+                        className="commentButton left"
+                        onClick={this.handleReadButton.bind(this, pr)}
+                      >
+                        {pr.hasNewComment ? 'Mark as read' : 'Mark as unread'}
                       </button>
                     </div>
                   }
@@ -412,6 +438,7 @@ class Github extends Component {
                 dense
                 primary="You do not have any followed repositories or option to display them
                   is not checked."
+                target
               />
             </ListItem>
           </Grid>
@@ -422,12 +449,56 @@ class Github extends Component {
   listComments(prObject) {
     if (prObject.commentsData.length > 0) {
       const length = prObject.commentsData.length;
-      const result = `${prObject.commentsData[length - 1].user.login}: ${
-        prObject.commentsData[length - 1].body
-      }`;
+      const lastComment = prObject.commentsData[length - 1];
+      const result = `${lastComment.user.login}: ${lastComment.body}`;
       return <ReactMarkdown className="noMargin" source={result} />;
     }
     return 'There are no comments';
+  }
+
+  saveInStorage() {
+    chrome.storage.local.set({
+      createdPR: this.state.createdPR,
+      assignedPR: this.state.assignedPR,
+      mentionedPR: this.state.mentionedPR,
+      reviewedPR: this.state.reviewedPR,
+      followedPR: this.state.followedPR,
+    });
+  }
+
+  markAsReadOrUnread(prObject, e) {
+    if (prObject.hasNewComment) {
+      prObject.hasNewComment = false;
+      e.target.parentNode.classList.remove('isNew');
+      e.target.innerHTML = 'Mark as unread';
+    } else {
+      prObject.hasNewComment = true;
+      e.target.parentNode.classList.add('isNew');
+      e.target.innerHTML = 'Mark as read';
+    }
+  }
+
+  handleReadButton(prObject, e) {
+    this.markAsReadOrUnread(prObject, e);
+    this.saveInStorage();
+  }
+
+  handleReadOnLoad(e) {
+    if (e) {
+      if (e.dataset.length == 0) {
+        e.classList.add('hidden');
+      }
+      if (e.dataset.isNew) {
+        e.innerHTML = 'Mark as read';
+      }
+    }
+  }
+
+  checkIfIsNew(e) {
+    if (e && e.dataset.isnew) {
+      console.log(e);
+      e.classList.add('isNew');
+    }
   }
 
   render() {

--- a/review-notifications/src/background.js
+++ b/review-notifications/src/background.js
@@ -263,7 +263,7 @@ async function checkForDifferences() {
   );
 }
 function checkDataFromChromeStorage(listOfPRs, stateName) {
-  if (listOfPRs.length > 0)
+  if (listOfPRs && listOfPRs.length > 0)
     state[stateName].map(currPR => {
       const pr = listOfPRs.find(resPr => resPr.link === currPR.link);
       if (pr) currPR.hasNewComment = pr.hasNewComment;


### PR DESCRIPTION
This pull request:
- adds distinction for read and unread comments,
- adds possibility to mark as read or unread,
- marks as read a comment when someone click on link to the PR of this comment.